### PR TITLE
[BC-17050] As a developer, when I am using the bugcrowd-templates as gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+# https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/
+Gemfile.lock

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,33 @@
+AllCops:
+  TargetRubyVersion: 2.5
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 120
+  IgnoreCopDirectives: true
+
+Metrics/BlockLength:
+  ExcludedMethods:
+    - configure
+    - context
+    - define
+    - describe
+    - draw
+    - factory
+    - feature
+    - guard
+    - included
+    - it
+    - let
+    - let!
+    - scenario
+    - setup
+    - shared_context
+    - shared_examples
+    - shared_examples_for
+    - transaction

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in bugcrowd_templates.gemspec
+gemspec

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'bugcrowd_templates'
+
+# You can add fixtures and/or initialization code here to make experimenting
+# with your gem easier. You can also use a different console, if you like.
+
+# (If you use this, don't forget to add pry to your Gemfile!)
+require 'pry'
+Pry.start

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/bugcrowd_templates.gemspec
+++ b/bugcrowd_templates.gemspec
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+lib = File.expand_path(__dir__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'date'
+require_relative 'lib/bugcrowd_templates/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'bugcrowd_templates'
+  spec.version       = BugcrowdTemplates::VERSION
+  spec.platform      = Gem::Platform::RUBY
+  spec.authors       = ['Rajkumar.U']
+  spec.email         = ['rajkumar.ulaganadhan@bugcrowd.com']
+  spec.date          = Date.today.to_s
+  spec.summary       = "Ruby wrapper for Bugcrowd\'s Templates for forms"
+  spec.homepage      = 'https://github.com/bugcrowd/templates'
+  spec.license       = 'MIT'
+  spec.files         = Dir['lib/**/*.{rb,json}']
+  spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.5'
+
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'pry', '~> 0.11'
+  spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'rspec', '~> 3.6'
+  spec.add_development_dependency 'rubocop', '0.56.0'
+
+  spec.metadata = {
+    'homepage_uri' => 'https://github.com/bugcrowd/templates',
+    'changelog_uri' => 'https://github.com/bugcrowd/templates/blob/master/CHANGELOG.md',
+    'source_code_uri' => 'https://github.com/bugcrowd/templates',
+    'bug_tracker_uri' => 'https://github.com/bugcrowd/templates/issues'
+  }
+end

--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -5,13 +5,29 @@ require 'pathname'
 require 'bugcrowd_templates/template_path'
 
 module BugcrowdTemplates
+  class TemplateNotFoundError < StandardError; end
+
   DATA_DIR = Pathname.new(Gem::Specification.find_by_name('bugcrowd_templates').gem_dir)
+
+  # if we need to add new template type
+  # we can add here
+  TEMPLATE_TYPES = {
+    submissions: 'submissions',
+    methodology: 'methodology'
+  }.freeze
 
   module_function
 
   # returns the Bugcrowd template based on given inputs
-  def get(template_type, template_field, *args)
-    template_category, template_subcategory, template_item = args
+  def get(
+    template_type: '',
+    template_field: '',
+    template_category: '',
+    template_subcategory: '',
+    template_item: ''
+  )
+
+    raise TemplateNotFoundError unless TEMPLATE_TYPES.value?(template_type)
 
     template_path = TemplatePath.new(
       type: template_type,

--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require_relative 'bugcrowd_templates/version'
+require 'pathname'
+require 'bugcrowd_templates/template_path'
+
+module BugcrowdTemplates
+  DATA_DIR = Pathname.new(Gem::Specification.find_by_name('bugcrowd_templates').gem_dir)
+
+  module_function
+
+  # returns the Bugcrowd template based on given inputs
+  def get(template_type, template_field, *args)
+    template_category, template_subcategory, template_item = args
+
+    template_path = TemplatePath.new(
+      type: template_type,
+      field: template_field,
+      category: template_category,
+      subcategory: template_subcategory,
+      item: template_item
+    ).template_file(template_type)
+
+    template_data(template_path)
+  end
+
+  def current_directory
+    DATA_DIR
+  end
+
+  def template_data(file_path)
+    File.open(file_path).read if File.exist?(file_path)
+  end
+end

--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -20,22 +20,22 @@ module BugcrowdTemplates
 
   # returns the Bugcrowd template based on given inputs
   def get(
-    template_type: '',
-    template_field: '',
-    template_category: '',
-    template_subcategory: '',
-    template_item: ''
+    type: '',
+    field: '',
+    category: '',
+    subcategory: '',
+    item: ''
   )
 
-    raise TemplateNotFoundError unless TEMPLATE_TYPES.value?(template_type)
+    raise TemplateNotFoundError unless TEMPLATE_TYPES.value?(type)
 
     template_path = TemplatePath.new(
-      type: template_type,
-      field: template_field,
-      category: template_category,
-      subcategory: template_subcategory,
-      item: template_item
-    ).template_file(template_type)
+      type: type,
+      field: field,
+      category: category,
+      subcategory: subcategory,
+      item: item
+    ).template_file(type)
 
     template_data(template_path)
   end

--- a/lib/bugcrowd_templates/template_path.rb
+++ b/lib/bugcrowd_templates/template_path.rb
@@ -7,7 +7,7 @@ module BugcrowdTemplates
     attr_reader :type, :field, :category, :subcategory, :item
 
     def initialize(type:, field:, category: '', subcategory: '', item: '')
-      @type = type
+      @type = type || ''
       @field = field || ''
       @category = category || ''
       @subcategory = subcategory || ''

--- a/lib/bugcrowd_templates/template_path.rb
+++ b/lib/bugcrowd_templates/template_path.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module BugcrowdTemplates
+  class TemplatePath
+    attr_reader :type, :field, :category, :subcategory, :item
+
+    def initialize(type:, field:, category: '', subcategory: '', item: '')
+      @type = type
+      @field = field || ''
+      @category = category || ''
+      @subcategory = subcategory || ''
+      @item = item || ''
+    end
+
+    def template_file(type)
+      file_pathname = case type
+                      when 'submissions'
+                        BugcrowdTemplates.current_directory.join(
+                          type, field, category, subcategory, item, 'template'
+                        )
+                      when 'methodology'
+                        BugcrowdTemplates.current_directory.join(type, field, category, subcategory, item)
+                      end
+      "#{file_pathname}.md"
+    end
+  end
+end

--- a/lib/bugcrowd_templates/template_path.rb
+++ b/lib/bugcrowd_templates/template_path.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module BugcrowdTemplates
+  class InputError < StandardError; end
+
   class TemplatePath
     attr_reader :type, :field, :category, :subcategory, :item
 
@@ -13,6 +15,8 @@ module BugcrowdTemplates
     end
 
     def template_file(type)
+      validate_input_attrs
+
       file_pathname = case type
                       when 'submissions'
                         BugcrowdTemplates.current_directory.join(
@@ -22,6 +26,16 @@ module BugcrowdTemplates
                         BugcrowdTemplates.current_directory.join(type, field, category, subcategory, item)
                       end
       "#{file_pathname}.md"
+    end
+
+    def valid?(input_str)
+      (input_str =~ /[^a-zA-Z_]/).nil?
+    end
+
+    def validate_input_attrs
+      [type, field, category, subcategory, item].each do |input_field|
+        raise InputError, 'Invalid input param(s)' unless valid?(input_field)
+      end
     end
   end
 end

--- a/lib/bugcrowd_templates/version.rb
+++ b/lib/bugcrowd_templates/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module BugcrowdTemplates
+  VERSION = '0.1.0'
+end

--- a/spec/bugcrowd_templates/template_path_spec.rb
+++ b/spec/bugcrowd_templates/template_path_spec.rb
@@ -73,7 +73,7 @@ describe BugcrowdTemplates::TemplatePath do
       end
     end
 
-    context 'when it has invalid params' do
+    context 'when it has incorrect params' do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'website_testing' }
@@ -82,6 +82,90 @@ describe BugcrowdTemplates::TemplatePath do
 
       it 'returns the template value' do
         is_expected.to eq("#{directory}/methodology/notes/website_testing.md")
+      end
+    end
+
+    context 'when it has invalid params' do
+      let!(:type) { '../../methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing_9' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+
+      it 'raises InputError' do
+        expect { subject }.to raise_error BugcrowdTemplates::InputError
+      end
+    end
+  end
+
+  describe '#valid?' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item
+      ).valid?(type)
+    end
+
+    context 'when correct input params' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'returns true' do
+        is_expected.to be_truthy
+      end
+    end
+
+    context 'when invalid input params' do
+      let!(:type) { '../../password' }
+      let!(:field) { '/../../testing_432' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'returns false' do
+        is_expected.to be_falsey
+      end
+    end
+  end
+
+  describe '#validate_input_attrs' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item
+      ).validate_input_attrs
+    end
+
+    context 'when correct input params' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { 'test' }
+
+      it 'returns the valid input params' do
+        is_expected.to eq [type, field, category, subcategory, item]
+      end
+    end
+
+    context 'when invalid input params' do
+      let!(:type) { '../../password' }
+      let!(:field) { '/../../testing_432' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'raises InputError' do
+        expect { subject }.to raise_error BugcrowdTemplates::InputError
       end
     end
   end

--- a/spec/bugcrowd_templates/template_path_spec.rb
+++ b/spec/bugcrowd_templates/template_path_spec.rb
@@ -1,0 +1,88 @@
+
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe BugcrowdTemplates::TemplatePath do
+  subject do
+    described_class.new(
+      type: type,
+      field: field,
+      category: category,
+      subcategory: subcategory,
+      item: item
+    )
+  end
+
+  describe '#new' do
+    context 'initialize with submission type' do
+      let!(:type) { 'submission' }
+      let!(:field) { 'description' }
+      let!(:category) { 'using_components_with_known_vulnerabilities' }
+      let!(:subcategory) { 'captcha_bypass' }
+      let!(:item) { 'ocr_optical_character_recognition' }
+
+      it 'initialize an item' do
+        expect(subject).to be_a(described_class)
+        expect(subject.type).to eq('submission')
+        expect(subject.field).to eq('description')
+        expect(subject.category).to eq('using_components_with_known_vulnerabilities')
+        expect(subject.subcategory).to eq('captcha_bypass')
+      end
+    end
+
+    context 'initialize with methodology type' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'initialize an item' do
+        expect(subject).to be_a(described_class)
+        expect(subject.type).to eq('methodology')
+        expect(subject.field).to eq('notes')
+        expect(subject.category).to eq('website_testing')
+        expect(subject.subcategory).to eq('information')
+      end
+    end
+  end
+
+  describe '#template_file' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item
+      ).template_file(type)
+    end
+
+    let(:directory) { BugcrowdTemplates.current_directory }
+
+    context 'when it has all the params' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'returns the template value' do
+        is_expected.to eq("#{directory}/methodology/notes/website_testing/information.md")
+      end
+    end
+
+    context 'when it has invalid params' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+
+      it 'returns the template value' do
+        is_expected.to eq("#{directory}/methodology/notes/website_testing.md")
+      end
+    end
+  end
+end

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -53,7 +53,7 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with invalid category' do
+    context 'with incorrect category' do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'testing' }
@@ -65,7 +65,7 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with invalid subcategory' do
+    context 'with incorrect subcategory' do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'testing' }
@@ -77,7 +77,7 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with invalid field' do
+    context 'with incorrect field' do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes_notes' }
       let!(:category) { 'testing' }
@@ -89,7 +89,7 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with invalid type' do
+    context 'with incorrect type' do
       let!(:type) { 'methodologysss' }
       let!(:field) { 'notes_notes' }
       let!(:category) { 'testing' }
@@ -101,7 +101,19 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with invalid params' do
+    context 'with upbase & downcase params' do
+      let!(:type) { 'METHODOLOGIESSS' }
+      let!(:field) { 'NOTES' }
+      let!(:category) { 'TESTING' }
+      let!(:subcategory) { 'hello' }
+      let!(:item) { 'world' }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with incorrect params' do
       let!(:type) { nil }
       let!(:field) { nil }
       let!(:category) { nil }

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -29,11 +29,11 @@ describe BugcrowdTemplates do
   describe '#get' do
     subject do
       described_class.get(
-        template_type: type,
-        template_field: field,
-        template_category: category,
-        template_subcategory: subcategory,
-        template_item: item
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item
       )
     end
 

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -1,0 +1,140 @@
+
+require 'spec_helper'
+
+describe BugcrowdTemplates do
+  describe '#VERSION' do
+    subject { described_class::VERSION }
+
+    it 'return current version for the gem' do
+      is_expected.to eq('0.1.0')
+    end
+  end
+
+  describe '#current_directory' do
+    subject { described_class.current_directory }
+
+    it 'return the current directory for the template' do
+      is_expected.to eq BugcrowdTemplates.current_directory
+    end
+  end
+
+  describe '#get' do
+    subject { described_class.get(type, field, category, subcategory, item) }
+
+    let(:type) { '' }
+    let(:field) { '' }
+    let(:category) { '' }
+    let(:subcategory) { '' }
+    let(:item) { '' }
+
+    context 'with correct params' do
+      context 'with methodology type' do
+        let!(:type) { 'methodology' }
+        let!(:field) { 'notes' }
+        let!(:category) { 'website_testing' }
+        let!(:subcategory) { 'information' }
+        let!(:item) { '' }
+
+        it 'returns the bugcrowd template value as string' do
+          is_expected.to include('# Information gathering')
+        end
+      end
+
+      context 'with submissions type' do
+        let!(:type) { 'submissions' }
+        let!(:field) { 'description' }
+        let!(:category) { 'using_components_with_known_vulnerabilities' }
+        let!(:subcategory) { 'captcha_bypass' }
+        let!(:item) { 'ocr_optical_character_recognition' }
+
+        it 'returns the bugcrowd template value as string' do
+          is_expected.to include('# Optical Character Recognition')
+        end
+      end
+    end
+
+    context 'with invalid category' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with invalid subcategory' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'testing' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with invalid field' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes_notes' }
+      let!(:category) { 'testing' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with invalid type' do
+      let!(:type) { 'methodologysss' }
+      let!(:field) { 'notes_notes' }
+      let!(:category) { 'testing' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with invalid params' do
+      let!(:type) { nil }
+      let!(:field) { nil }
+      let!(:category) { nil }
+      let!(:subcategory) { nil }
+      let!(:item) { nil }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with only type param' do
+      let!(:type) { 'methodology' }
+      let!(:field) { nil }
+      let!(:category) { nil }
+      let!(:subcategory) { nil }
+      let!(:item) { nil }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+
+    context 'with only field param' do
+      let!(:type) { nil }
+      let!(:field) { 'description' }
+      let!(:category) { nil }
+      let!(:subcategory) { nil }
+      let!(:item) { nil }
+
+      it 'returns the nil value' do
+        is_expected.to be_nil
+      end
+    end
+  end
+end

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -136,5 +136,53 @@ describe BugcrowdTemplates do
         is_expected.to be_nil
       end
     end
+
+    context 'with invalid input params' do
+      let!(:type) { '../../../../etc/passwd' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+
+      it 'raises InputError' do
+        expect { subject }.to raise_error BugcrowdTemplates::InputError
+      end
+
+      context 'with special character params' do
+        let!(:type) { 'methodology' }
+        let!(:field) { 'notes..@' }
+        let!(:category) { 'testing-testing' }
+        let!(:subcategory) { 'information' }
+        let!(:item) { '' }
+
+        it 'raises InputError' do
+          expect { subject }.to raise_error BugcrowdTemplates::InputError
+        end
+      end
+
+      context 'with number params' do
+        let!(:type) { 'methodology' }
+        let!(:field) { 'test_646' }
+        let!(:category) { 'testing-testing-87' }
+        let!(:subcategory) { 'information' }
+        let!(:item) { '' }
+
+        it 'raises InputError' do
+          expect { subject }.to raise_error BugcrowdTemplates::InputError
+        end
+      end
+
+      context 'with multiple special character params' do
+        let!(:type) { '#methodology' }
+        let!(:field) { 'test_646' }
+        let!(:category) { 'testing&-testing-87' }
+        let!(:subcategory) { 'infor%mation' }
+        let!(:item) { '' }
+
+        it 'raises InputError' do
+          expect { subject }.to raise_error BugcrowdTemplates::InputError
+        end
+      end
+    end
   end
 end

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -10,6 +10,14 @@ describe BugcrowdTemplates do
     end
   end
 
+  describe '#TEMPLATE_TYPES' do
+    subject { described_class::TEMPLATE_TYPES }
+
+    it 'return template types' do
+      is_expected.to eq(methodology: 'methodology', submissions: 'submissions')
+    end
+  end
+
   describe '#current_directory' do
     subject { described_class.current_directory }
 
@@ -19,7 +27,15 @@ describe BugcrowdTemplates do
   end
 
   describe '#get' do
-    subject { described_class.get(type, field, category, subcategory, item) }
+    subject do
+      described_class.get(
+        template_type: type,
+        template_field: field,
+        template_category: category,
+        template_subcategory: subcategory,
+        template_item: item
+      )
+    end
 
     let(:type) { '' }
     let(:field) { '' }
@@ -96,8 +112,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { '' }
       let!(:item) { '' }
 
-      it 'returns the nil value' do
-        is_expected.to be_nil
+      it 'raises TemplateNotFoundError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
       end
     end
 
@@ -108,8 +124,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { 'hello' }
       let!(:item) { 'world' }
 
-      it 'returns the nil value' do
-        is_expected.to be_nil
+      it 'raises TemplateNotFoundError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
       end
     end
 
@@ -120,8 +136,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { nil }
       let!(:item) { nil }
 
-      it 'returns the nil value' do
-        is_expected.to be_nil
+      it 'raises TemplateNotFoundError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
       end
     end
 
@@ -144,14 +160,14 @@ describe BugcrowdTemplates do
       let!(:subcategory) { nil }
       let!(:item) { nil }
 
-      it 'returns the nil value' do
-        is_expected.to be_nil
+      it 'raises TemplateNotFoundError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
       end
     end
 
     context 'with invalid input params' do
-      let!(:type) { '../../../../etc/passwd' }
-      let!(:field) { 'notes' }
+      let!(:type) { 'methodology' }
+      let!(:field) { '../../etc/password' }
       let!(:category) { 'testing' }
       let!(:subcategory) { 'information' }
       let!(:item) { '' }
@@ -185,7 +201,7 @@ describe BugcrowdTemplates do
       end
 
       context 'with multiple special character params' do
-        let!(:type) { '#methodology' }
+        let!(:type) { 'methodology' }
         let!(:field) { 'test_646' }
         let!(:category) { 'testing&-testing-87' }
         let!(:subcategory) { 'infor%mation' }
@@ -193,6 +209,30 @@ describe BugcrowdTemplates do
 
         it 'raises InputError' do
           expect { subject }.to raise_error BugcrowdTemplates::InputError
+        end
+      end
+
+      context 'when there is no params' do
+        let!(:type) {}
+        let!(:field) {}
+        let!(:category) {}
+        let!(:subcategory) {}
+        let!(:item) {}
+
+        it 'raises TemplateNotFoundError' do
+          expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+        end
+      end
+
+      context 'when it has correct type & other params as empty' do
+        let!(:type) { 'submissions' }
+        let!(:field) {}
+        let!(:category) {}
+        let!(:subcategory) {}
+        let!(:item) {}
+
+        it 'returns the nil value' do
+          is_expected.to be_nil
         end
       end
     end

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -101,7 +101,7 @@ describe BugcrowdTemplates do
       end
     end
 
-    context 'with upbase & downcase params' do
+    context 'with incorrect up & down case params' do
       let!(:type) { 'METHODOLOGIESSS' }
       let!(:field) { 'NOTES' }
       let!(:category) { 'TESTING' }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'bundler/setup'
+require 'bugcrowd_templates'
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
### User Story
As a developer
when I am using the bugcrowd-templates gem
I can easily get the right template for my form and field

### Technical explanation 

- Added a gem as `bugcrowd_templates`.
- Added gemspec
- Added basic test cases
- If there is no template, it will return nil value

### To test
In `bin/console` run the below commands

```

BugcrowdTemplates.get(type: 'methodology', field: 'notes', category: 'website_testing', subcategory: 'information')

BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'application_level_denial_of_service_dos', subcategory: 'critical_impact_and_or_easy_difficulty')

BugcrowdTemplates.get(
          type: 'submissions',
          field: 'description',
          category: 'server_security_misconfiguration',
          subcategory: 'mail_server_misconfiguration',
          item: 'missing_or_misconfigured_spf_and_or_dkim'
        )
```

You can see the template based on given inputs


<img width="1656" alt="Screenshot 2021-08-18 at 8 51 31 PM" src="https://user-images.githubusercontent.com/57894121/129925599-e36086c0-a078-4a22-90d0-dba54670b780.png">