### PR TITLE
changed the error class TemplateNotFoundError to TypeError

### DIFF
--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -5,7 +5,7 @@ require 'pathname'
 require 'bugcrowd_templates/template_path'
 
 module BugcrowdTemplates
-  class TemplateNotFoundError < StandardError; end
+  class TypeError < StandardError; end
 
   DATA_DIR = Pathname.new(Gem::Specification.find_by_name('bugcrowd_templates').gem_dir)
 
@@ -27,7 +27,7 @@ module BugcrowdTemplates
     item: ''
   )
 
-    raise TemplateNotFoundError unless TEMPLATE_TYPES.value?(type)
+    raise TypeError, 'Invalid template type' unless TEMPLATE_TYPES.value?(type)
 
     template_path = TemplatePath.new(
       type: type,

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -112,8 +112,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { '' }
       let!(:item) { '' }
 
-      it 'raises TemplateNotFoundError' do
-        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+      it 'raises TypeError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TypeError
       end
     end
 
@@ -124,8 +124,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { 'hello' }
       let!(:item) { 'world' }
 
-      it 'raises TemplateNotFoundError' do
-        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+      it 'raises TypeError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TypeError
       end
     end
 
@@ -136,8 +136,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { nil }
       let!(:item) { nil }
 
-      it 'raises TemplateNotFoundError' do
-        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+      it 'raises TypeError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TypeError
       end
     end
 
@@ -160,8 +160,8 @@ describe BugcrowdTemplates do
       let!(:subcategory) { nil }
       let!(:item) { nil }
 
-      it 'raises TemplateNotFoundError' do
-        expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+      it 'raises TypeError' do
+        expect { subject }.to raise_error BugcrowdTemplates::TypeError
       end
     end
 
@@ -219,8 +219,8 @@ describe BugcrowdTemplates do
         let!(:subcategory) {}
         let!(:item) {}
 
-        it 'raises TemplateNotFoundError' do
-          expect { subject }.to raise_error BugcrowdTemplates::TemplateNotFoundError
+        it 'raises TypeError' do
+          expect { subject }.to raise_error BugcrowdTemplates::TypeError
         end
       end
 


### PR DESCRIPTION
### User story
Changing the error message in the gem `bugcrowd_templates`. The error message changing from `BugcrowdTemplates::TemplateNotFoundError` to `BugcrowdTemplates::TypeError: Invalid template type`

Based on this ticket : https://bugcrowd.atlassian.net/browse/BC-17051


**Reasons**: 

When we are calling the api with invalid type it is giving, `TemplateNotFoundError`. it is making confusion to the user, to resolve that changing the error message for invalid template type.

**Before the change:**
when we are passing the `type` as `invalid` instead of `methodology`. it will give the below error
```
BugcrowdTemplates.get(type: 'invalid', field: 'notes', category: 'website_testing', subcategory: 'information')
=> BugcrowdTemplates::TemplateNotFoundError: BugcrowdTemplates::TemplateNotFoundError
```

**After the change:**
When we are passing the `type` as `invalid` instead of `methodology`. it will give the below error

```
BugcrowdTemplates.get(type: 'invalid', field: 'notes', category: 'website_testing', subcategory: 'information')
=> BugcrowdTemplates::TypeError: Invalid template type
```

### To test
 1. run the `bin/console` to open the console

`BugcrowdTemplates.get(type: 'test', field: 'notes', category: 'website_testing', subcategory: 'information')`

<img width="1308" alt="Screenshot 2021-09-02 at 2 29 28 PM" src="https://user-images.githubusercontent.com/57894121/131818924-aae1dbec-04c1-4781-90c2-802f52b2b8a5.png">


