### PR TITLE
[BC-18469] as BugcrowdTemplate gem, when I search for a template and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ BugcrowdTemplates.get(
   type: 'methodology',
   field: 'notes', # field name of the methodologies
   category: 'website_testing',
-  subcategory: 'information'
+  file_name: 'information'
 )
 => '# Information gathering and Reconnaisance\n\n##' # template fetched from templates path
 ```

--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -38,9 +38,9 @@ module BugcrowdTemplates
       subcategory: subcategory,
       item: item,
       file_name: file_name
-    ).template_file(type)
+    ).template_file
 
-    template_data(file_path: template_path, category: category, subcategory: subcategory, item: item)
+    template_data(template_path)
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -48,44 +48,7 @@ module BugcrowdTemplates
     DATA_DIR
   end
 
-  def template_data(file_path:, category:, subcategory:, item:)
-    if File.exist?(file_path)
-      File.open(file_path).read
-    else
-      find_template(file_path, category, subcategory, item)
-    end
-  end
-
-  def find_template(file_path, category, subcategory, item)
-    return File.open(file_path).read if File.exist?(file_path)
-
-    file_path = get_pathname(file_path)
-    presented_template(file_path, category, subcategory, item)
-  end
-
-  def get_pathname(file_path)
-    Pathname.new(file_path)
-  end
-
-  def get_parent_path(file_path)
-    File.dirname(file_path.parent)
-  end
-
-  def get_file_basename(file_path)
-    File.basename(file_path)
-  end
-
-  # when there is no template.md in `item_1` folder
-  # It will look the parent folder in `sub_category_1`
-  # return the template as `category_1/sub_category_1/template.md`
-  def presented_template(file_path, category, subcategory, item)
-    parent_path_template = get_parent_path(file_path) + '/' + get_file_basename(file_path)
-
-    # check the parent directory templates within in the category, subcategory & item folders only
-    if [category, subcategory, item].include?(get_pathname(get_parent_path(file_path)).basename.to_s)
-      template_data(file_path: parent_path_template, category: category, subcategory: subcategory, item: item)
-    elsif File.exist?(parent_path_template)
-      return File.open(parent_path_template).read
-    end
+  def template_data(file_path)
+    File.open(file_path).read if file_path && File.exist?(file_path)
   end
 end

--- a/lib/bugcrowd_templates.rb
+++ b/lib/bugcrowd_templates.rb
@@ -40,7 +40,7 @@ module BugcrowdTemplates
       file_name: file_name
     ).template_file(type)
 
-    template_data(template_path)
+    template_data(file_path: template_path, category: category, subcategory: subcategory, item: item)
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -48,7 +48,44 @@ module BugcrowdTemplates
     DATA_DIR
   end
 
-  def template_data(file_path)
-    File.open(file_path).read if File.exist?(file_path)
+  def template_data(file_path:, category:, subcategory:, item:)
+    if File.exist?(file_path)
+      File.open(file_path).read
+    else
+      find_template(file_path, category, subcategory, item)
+    end
+  end
+
+  def find_template(file_path, category, subcategory, item)
+    return File.open(file_path).read if File.exist?(file_path)
+
+    file_path = get_pathname(file_path)
+    presented_template(file_path, category, subcategory, item)
+  end
+
+  def get_pathname(file_path)
+    Pathname.new(file_path)
+  end
+
+  def get_parent_path(file_path)
+    File.dirname(file_path.parent)
+  end
+
+  def get_file_basename(file_path)
+    File.basename(file_path)
+  end
+
+  # when there is no template.md in `item_1` folder
+  # It will look the parent folder in `sub_category_1`
+  # return the template as `category_1/sub_category_1/template.md`
+  def presented_template(file_path, category, subcategory, item)
+    parent_path_template = get_parent_path(file_path) + '/' + get_file_basename(file_path)
+
+    # check the parent directory templates within in the category, subcategory & item folders only
+    if [category, subcategory, item].include?(get_pathname(get_parent_path(file_path)).basename.to_s)
+      template_data(file_path: parent_path_template, category: category, subcategory: subcategory, item: item)
+    elsif File.exist?(parent_path_template)
+      return File.open(parent_path_template).read
+    end
   end
 end

--- a/lib/bugcrowd_templates/template_path.rb
+++ b/lib/bugcrowd_templates/template_path.rb
@@ -36,35 +36,31 @@ module BugcrowdTemplates
     # check upto item directory, and return if template exist
     # e.g: `templates/submissions/description/server_security_misconfiguration/clickjacking/form_input/template.md`
     def item_file_path
-      item_path = BugcrowdTemplates.current_directory.join(
-        type, field, category, subcategory, item, file_name
-      )
+      file_name_with_extension = [file_name, 'md'].join('.')
 
-      file_path_url(item_path)
+      BugcrowdTemplates.current_directory.join(
+        type, field, category, subcategory, item, file_name_with_extension
+      )
     end
 
     # check upto subcategory directory, and return if template exist
     # e.g: `templates/submissions/description/server_security_misconfiguration/clickjacking/template.md`
     def subcategory_file_path
-      subcategory_path = BugcrowdTemplates.current_directory.join(
-        type, field, category, subcategory, file_name
-      )
+      file_name_with_extension = [file_name, 'md'].join('.')
 
-      file_path_url(subcategory_path)
+      BugcrowdTemplates.current_directory.join(
+        type, field, category, subcategory, file_name_with_extension
+      )
     end
 
     # check upto category directory, and return if template exist
     # e.g: `templates/submissions/description/server_security_misconfiguration/template.md`
     def category_file_path
-      category_path = BugcrowdTemplates.current_directory.join(
-        type, field, category, file_name
+      file_name_with_extension = [file_name, 'md'].join('.')
+
+      BugcrowdTemplates.current_directory.join(
+        type, field, category, file_name_with_extension
       )
-
-      file_path_url(category_path)
-    end
-
-    def file_path_url(file_path)
-      "#{file_path}.md"
     end
 
     def valid?(input_str)

--- a/lib/bugcrowd_templates/template_path.rb
+++ b/lib/bugcrowd_templates/template_path.rb
@@ -17,18 +17,54 @@ module BugcrowdTemplates
     end
     # rubocop:enable Metrics/ParameterLists, Metrics/CyclomaticComplexity
 
-    def template_file(type)
+    def template_file
       validate_input_attrs
 
-      file_pathname = case type
-                      when 'submissions'
-                        BugcrowdTemplates.current_directory.join(
-                          type, field, category, subcategory, item, file_name
-                        )
-                      when 'methodology'
-                        BugcrowdTemplates.current_directory.join(type, field, category, subcategory, item)
-                      end
-      "#{file_pathname}.md"
+      find_template_file
+    end
+
+    # find the template file from  `category/subcategory/item` directories, checking from item to category level
+    # when dir is `item` then it will return `.../submissions/description/category/subcategory/item/template.md`
+    # when dir is `subcategory` then it will return  `.../submissions/description/category/subcategory/template.md`
+    # when dir is `category` then it will return `.../submissions/description/category/template.md`
+    def find_template_file
+      return item_file_path if item && File.exist?(item_file_path)
+      return subcategory_file_path if subcategory && File.exist?(subcategory_file_path)
+      category_file_path
+    end
+
+    # check upto item directory, and return if template exist
+    # e.g: `templates/submissions/description/server_security_misconfiguration/clickjacking/form_input/template.md`
+    def item_file_path
+      item_path = BugcrowdTemplates.current_directory.join(
+        type, field, category, subcategory, item, file_name
+      )
+
+      file_path_url(item_path)
+    end
+
+    # check upto subcategory directory, and return if template exist
+    # e.g: `templates/submissions/description/server_security_misconfiguration/clickjacking/template.md`
+    def subcategory_file_path
+      subcategory_path = BugcrowdTemplates.current_directory.join(
+        type, field, category, subcategory, file_name
+      )
+
+      file_path_url(subcategory_path)
+    end
+
+    # check upto category directory, and return if template exist
+    # e.g: `templates/submissions/description/server_security_misconfiguration/template.md`
+    def category_file_path
+      category_path = BugcrowdTemplates.current_directory.join(
+        type, field, category, file_name
+      )
+
+      file_path_url(category_path)
+    end
+
+    def file_path_url(file_path)
+      "#{file_path}.md"
     end
 
     def valid?(input_str)

--- a/spec/bugcrowd_templates/template_path_spec.rb
+++ b/spec/bugcrowd_templates/template_path_spec.rb
@@ -61,7 +61,7 @@ describe BugcrowdTemplates::TemplatePath do
         subcategory: subcategory,
         item: item,
         file_name: file_name
-      ).template_file(type)
+      ).template_file
     end
 
     let(:directory) { BugcrowdTemplates.current_directory }
@@ -72,7 +72,7 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:category) { 'website_testing' }
       let!(:subcategory) { 'information' }
       let!(:item) { '' }
-      let!(:file_name) { 'template' }
+      let!(:file_name) { '' }
 
       it 'returns the template value' do
         is_expected.to eq("#{directory}/methodology/notes/website_testing/information.md")
@@ -102,6 +102,226 @@ describe BugcrowdTemplates::TemplatePath do
 
       it 'raises InputError' do
         expect { subject }.to raise_error BugcrowdTemplates::InputError
+      end
+    end
+  end
+
+  describe '#find_template_file' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item,
+        file_name: file_name
+      ).find_template_file
+    end
+
+    let(:dir) { BugcrowdTemplates.current_directory }
+
+    context 'when item folder is not having template for submissions' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'server_security_misconfiguration' }
+      let!(:subcategory) { 'clickjacking' }
+      let!(:item) { 'form_input' }
+      let!(:file_name) { 'template' }
+
+      it 'returns the template from the subcategory folder as template' do
+        is_expected.to eq("#{dir}/submissions/description/server_security_misconfiguration/clickjacking/template.md")
+      end
+    end
+
+    context 'when it has category params for submissions' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'using_components_with_known_vulnerabilities' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+      let!(:file_name) { 'template' }
+
+      it 'returns the category folder as template' do
+        is_expected.to eq("#{dir}/submissions/description/using_components_with_known_vulnerabilities/template.md")
+      end
+    end
+
+    context 'when item folder is not having template for methodology' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+      let!(:file_name) { '' }
+
+      it 'returns the methodology template' do
+        is_expected.to eq("#{dir}/methodology/notes/website_testing/information.md")
+      end
+    end
+  end
+
+  describe '#item_file_path' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item,
+        file_name: file_name
+      ).item_file_path
+    end
+
+    let(:dir) { BugcrowdTemplates.current_directory }
+
+    context 'when searching item folder for submissions' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'server_security' }
+      let!(:subcategory) { 'clickjacking' }
+      let!(:item) { 'form' }
+      let!(:file_name) { 'template' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/submissions/description/server_security/clickjacking/form/template.md")
+      end
+    end
+
+    context 'when searching item folder for methodology' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { 'infor' }
+      let!(:file_name) { '' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/methodology/notes/website_testing/information/infor.md")
+      end
+    end
+  end
+
+  describe '#subcategory_file_path' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item,
+        file_name: file_name
+      ).subcategory_file_path
+    end
+
+    let(:dir) { BugcrowdTemplates.current_directory }
+
+    context 'when searching subcategory folder for submissions' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'server_security' }
+      let!(:subcategory) { 'clickjacking' }
+      let!(:item) { '' }
+      let!(:file_name) { 'template' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/submissions/description/server_security/clickjacking/template.md")
+      end
+    end
+
+    context 'when searching subcategory folder for methodology' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+      let!(:file_name) { '' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/methodology/notes/website_testing/information.md")
+      end
+    end
+  end
+
+  describe '#category_file_path' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item,
+        file_name: file_name
+      ).category_file_path
+    end
+
+    let(:dir) { BugcrowdTemplates.current_directory }
+
+    context 'when searching category folder for submissions' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'server_security' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+      let!(:file_name) { 'template' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/submissions/description/server_security/template.md")
+      end
+    end
+
+    context 'when searching category folder for methodology' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { '' }
+      let!(:item) { '' }
+      let!(:file_name) { '' }
+
+      it 'returns the template' do
+        is_expected.to eq("#{dir}/methodology/notes/website_testing.md")
+      end
+    end
+  end
+
+  describe '#file_path_url' do
+    subject do
+      described_class.new(
+        type: type,
+        field: field,
+        category: category,
+        subcategory: subcategory,
+        item: item,
+        file_name: file_name
+      ).file_path_url(file_path)
+    end
+
+    let(:dir) { BugcrowdTemplates.current_directory }
+
+    context 'when file path for submission' do
+      let!(:type) { 'submissions' }
+      let!(:field) { 'description' }
+      let!(:category) { 'server_security' }
+      let!(:subcategory) { 'subcategory' }
+      let!(:item) { 'item' }
+      let!(:file_name) { 'template' }
+      let(:file_path) { '/category/subcategory/item/template' }
+
+      it 'returns the template' do
+        is_expected.to eq('/category/subcategory/item/template.md')
+      end
+    end
+
+    context 'when file path for methodology' do
+      let!(:type) { 'methodology' }
+      let!(:field) { 'notes' }
+      let!(:category) { 'website_testing' }
+      let!(:subcategory) { 'information' }
+      let!(:item) { '' }
+      let!(:file_name) { '' }
+      let(:file_path) { '/methodology/notes/website_testing/information' }
+
+      it 'returns the template' do
+        is_expected.to eq('/methodology/notes/website_testing/information.md')
       end
     end
   end

--- a/spec/bugcrowd_templates/template_path_spec.rb
+++ b/spec/bugcrowd_templates/template_path_spec.rb
@@ -15,6 +15,9 @@ describe BugcrowdTemplates::TemplatePath do
     )
   end
 
+  let!(:directory) { BugcrowdTemplates.current_directory }
+  let!(:file_name_with_extension) { [file_name, 'md'].join('.') }
+
   describe '#new' do
     context 'initialize with submission type' do
       let!(:type) { 'submission' }
@@ -64,18 +67,18 @@ describe BugcrowdTemplates::TemplatePath do
       ).template_file
     end
 
-    let(:directory) { BugcrowdTemplates.current_directory }
+    let!(:result) { directory.join(type, field, category, subcategory, item, file_name_with_extension) }
 
     context 'when it has all the params' do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'website_testing' }
-      let!(:subcategory) { 'information' }
+      let!(:subcategory) { '' }
       let!(:item) { '' }
-      let!(:file_name) { '' }
+      let!(:file_name) { 'information' }
 
       it 'returns the template value' do
-        is_expected.to eq("#{directory}/methodology/notes/website_testing/information.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -88,7 +91,7 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:file_name) { '' }
 
       it 'returns the template value' do
-        is_expected.to eq("#{directory}/methodology/notes/website_testing.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -118,8 +121,6 @@ describe BugcrowdTemplates::TemplatePath do
       ).find_template_file
     end
 
-    let(:dir) { BugcrowdTemplates.current_directory }
-
     context 'when item folder is not having template for submissions' do
       let!(:type) { 'submissions' }
       let!(:field) { 'description' }
@@ -127,9 +128,10 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:subcategory) { 'clickjacking' }
       let!(:item) { 'form_input' }
       let!(:file_name) { 'template' }
+      let!(:result) { directory.join(type, field, category, subcategory, file_name_with_extension) }
 
       it 'returns the template from the subcategory folder as template' do
-        is_expected.to eq("#{dir}/submissions/description/server_security_misconfiguration/clickjacking/template.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -140,9 +142,10 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:subcategory) { '' }
       let!(:item) { '' }
       let!(:file_name) { 'template' }
+      let!(:result) { directory.join(type, field, category, file_name_with_extension) }
 
       it 'returns the category folder as template' do
-        is_expected.to eq("#{dir}/submissions/description/using_components_with_known_vulnerabilities/template.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -150,12 +153,13 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'website_testing' }
-      let!(:subcategory) { 'information' }
+      let!(:subcategory) { '' }
       let!(:item) { '' }
-      let!(:file_name) { '' }
+      let!(:file_name) { 'information' }
+      let!(:result) { directory.join(type, field, category, file_name_with_extension) }
 
       it 'returns the methodology template' do
-        is_expected.to eq("#{dir}/methodology/notes/website_testing/information.md")
+        is_expected.to eq(result)
       end
     end
   end
@@ -172,8 +176,6 @@ describe BugcrowdTemplates::TemplatePath do
       ).item_file_path
     end
 
-    let(:dir) { BugcrowdTemplates.current_directory }
-
     context 'when searching item folder for submissions' do
       let!(:type) { 'submissions' }
       let!(:field) { 'description' }
@@ -181,9 +183,10 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:subcategory) { 'clickjacking' }
       let!(:item) { 'form' }
       let!(:file_name) { 'template' }
+      let!(:result) { directory.join(type, field, category, subcategory, item, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/submissions/description/server_security/clickjacking/form/template.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -192,11 +195,12 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:field) { 'notes' }
       let!(:category) { 'website_testing' }
       let!(:subcategory) { 'information' }
-      let!(:item) { 'infor' }
-      let!(:file_name) { '' }
+      let!(:item) { 'api_testing' }
+      let!(:file_name) { 'testing' }
+      let!(:result) { directory.join(type, field, category, subcategory, item, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/methodology/notes/website_testing/information/infor.md")
+        is_expected.to eq(result)
       end
     end
   end
@@ -213,8 +217,6 @@ describe BugcrowdTemplates::TemplatePath do
       ).subcategory_file_path
     end
 
-    let(:dir) { BugcrowdTemplates.current_directory }
-
     context 'when searching subcategory folder for submissions' do
       let!(:type) { 'submissions' }
       let!(:field) { 'description' }
@@ -222,9 +224,10 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:subcategory) { 'clickjacking' }
       let!(:item) { '' }
       let!(:file_name) { 'template' }
+      let!(:result) { directory.join(type, field, category, subcategory, item, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/submissions/description/server_security/clickjacking/template.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -232,12 +235,13 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:type) { 'methodology' }
       let!(:field) { 'notes' }
       let!(:category) { 'website_testing' }
-      let!(:subcategory) { 'information' }
+      let!(:subcategory) { '' }
       let!(:item) { '' }
-      let!(:file_name) { '' }
+      let!(:file_name) { 'information' }
+      let!(:result) { directory.join(type, field, category, subcategory, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/methodology/notes/website_testing/information.md")
+        is_expected.to eq(result)
       end
     end
   end
@@ -254,8 +258,6 @@ describe BugcrowdTemplates::TemplatePath do
       ).category_file_path
     end
 
-    let(:dir) { BugcrowdTemplates.current_directory }
-
     context 'when searching category folder for submissions' do
       let!(:type) { 'submissions' }
       let!(:field) { 'description' }
@@ -263,9 +265,10 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:subcategory) { '' }
       let!(:item) { '' }
       let!(:file_name) { 'template' }
+      let!(:result) { directory.join(type, field, category, subcategory, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/submissions/description/server_security/template.md")
+        is_expected.to eq(result)
       end
     end
 
@@ -275,53 +278,11 @@ describe BugcrowdTemplates::TemplatePath do
       let!(:category) { 'website_testing' }
       let!(:subcategory) { '' }
       let!(:item) { '' }
-      let!(:file_name) { '' }
+      let!(:file_name) { 'information' }
+      let!(:result) { directory.join(type, field, category, subcategory, file_name_with_extension) }
 
       it 'returns the template' do
-        is_expected.to eq("#{dir}/methodology/notes/website_testing.md")
-      end
-    end
-  end
-
-  describe '#file_path_url' do
-    subject do
-      described_class.new(
-        type: type,
-        field: field,
-        category: category,
-        subcategory: subcategory,
-        item: item,
-        file_name: file_name
-      ).file_path_url(file_path)
-    end
-
-    let(:dir) { BugcrowdTemplates.current_directory }
-
-    context 'when file path for submission' do
-      let!(:type) { 'submissions' }
-      let!(:field) { 'description' }
-      let!(:category) { 'server_security' }
-      let!(:subcategory) { 'subcategory' }
-      let!(:item) { 'item' }
-      let!(:file_name) { 'template' }
-      let(:file_path) { '/category/subcategory/item/template' }
-
-      it 'returns the template' do
-        is_expected.to eq('/category/subcategory/item/template.md')
-      end
-    end
-
-    context 'when file path for methodology' do
-      let!(:type) { 'methodology' }
-      let!(:field) { 'notes' }
-      let!(:category) { 'website_testing' }
-      let!(:subcategory) { 'information' }
-      let!(:item) { '' }
-      let!(:file_name) { '' }
-      let(:file_path) { '/methodology/notes/website_testing/information' }
-
-      it 'returns the template' do
-        is_expected.to eq('/methodology/notes/website_testing/information.md')
+        is_expected.to eq(result)
       end
     end
   end

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -50,9 +50,9 @@ describe BugcrowdTemplates do
         let!(:type) { 'methodology' }
         let!(:field) { 'notes' }
         let!(:category) { 'website_testing' }
-        let!(:subcategory) { 'information' }
+        let!(:subcategory) { '' }
         let!(:item) { '' }
-        let!(:file_name) { '' }
+        let!(:file_name) { 'information' }
 
         it 'returns the bugcrowd template value as string' do
           is_expected.to include('# Information gathering')
@@ -233,9 +233,9 @@ describe BugcrowdTemplates do
         let!(:type) { 'methodology' }
         let!(:field) { 'notes' }
         let!(:category) { 'website_testing' }
-        let!(:subcategory) { 'information' }
+        let!(:subcategory) { '' }
         let!(:item) { '' }
-        let!(:file_name) { '' }
+        let!(:file_name) { 'information' }
 
         it 'returns the methodology template value as string' do
           is_expected.to include('# Information gathering')

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -52,7 +52,7 @@ describe BugcrowdTemplates do
         let!(:category) { 'website_testing' }
         let!(:subcategory) { 'information' }
         let!(:item) { '' }
-        let!(:file_name) { 'template' }
+        let!(:file_name) { '' }
 
         it 'returns the bugcrowd template value as string' do
           is_expected.to include('# Information gathering')
@@ -235,7 +235,7 @@ describe BugcrowdTemplates do
         let!(:category) { 'website_testing' }
         let!(:subcategory) { 'information' }
         let!(:item) { '' }
-        let!(:file_name) { 'template' }
+        let!(:file_name) { '' }
 
         it 'returns the methodology template value as string' do
           is_expected.to include('# Information gathering')

--- a/spec/bugcrowd_templates_spec.rb
+++ b/spec/bugcrowd_templates_spec.rb
@@ -91,6 +91,7 @@ describe BugcrowdTemplates do
           context 'file_name as guidance' do
             let!(:file_name) { 'guidance' }
 
+            # need to change the when it has guidance template
             it 'returns the nil for not presence of template' do
               is_expected.to be_nil
             end
@@ -103,6 +104,141 @@ describe BugcrowdTemplates do
               expect { subject }.to raise_error BugcrowdTemplates::InputError
             end
           end
+        end
+
+        context 'when file_name with multiple options' do
+          context 'file_name as template' do
+            let!(:file_name) { 'template' }
+
+            it 'returns the bugcrowd template value as string' do
+              is_expected.to include('# Outdated Software Version')
+            end
+          end
+
+          context 'file_name as testing' do
+            let!(:file_name) { 'testing' }
+
+            it 'returns the nil for not presence of template' do
+              is_expected.to be_nil
+            end
+          end
+
+          context 'file_name as guidance' do
+            let!(:file_name) { 'guidance' }
+
+            # need to change the when it has guidance template
+            it 'returns the nil for not presence of template' do
+              is_expected.to be_nil
+            end
+          end
+
+          context 'file_name as $5%' do
+            let!(:file_name) { '$5%' }
+
+            it 'returns the error message for invalid name' do
+              expect { subject }.to raise_error BugcrowdTemplates::InputError
+            end
+          end
+        end
+      end
+
+      context 'when a user searching templates with different vrt items' do
+        let!(:type) { 'submissions' }
+        let!(:field) { 'description' }
+        let!(:category) { category }
+        let!(:subcategory) { subcategory }
+        let!(:item) { item }
+        let!(:file_name) { template }
+
+        context 'when there is no template in item folder' do
+          let!(:category) { 'server_security_misconfiguration' }
+          let!(:subcategory) { 'clickjacking' }
+          let!(:item) { 'form_input' }
+          let!(:file_name) { 'template' }
+
+          it 'returns the template defined in the subcategory folder' do
+            is_expected.to include('# Clickjacking')
+          end
+        end
+
+        context 'when there is no item params' do
+          let!(:category) { 'server_security_misconfiguration' }
+          let!(:subcategory) { 'clickjacking' }
+          let!(:item) { '' }
+          let!(:file_name) { 'template' }
+
+          it 'returns the template defined in the subcategory folder' do
+            is_expected.to include('# Clickjacking')
+          end
+        end
+
+        context 'with category, subcategory & template' do
+          let!(:category) { 'using_components_with_known_vulnerabilities' }
+          let!(:subcategory) { 'outdated_software_version' }
+          let!(:item) { '' }
+          let!(:file_name) { 'template' }
+
+          it 'returns the template defined in the subcategory folder' do
+            is_expected.to include('# Outdated Software Version')
+          end
+        end
+
+        context 'with category, subcategory & guidance' do
+          let!(:category) { 'using_components_with_known_vulnerabilities' }
+          let!(:subcategory) { 'outdated_software_version' }
+          let!(:item) { '' }
+          let!(:file_name) { 'guidance' }
+
+          # need to change the when it has guidance template
+          it 'returns the guidance defined in the subcategory folder' do
+            is_expected.to be_nil
+          end
+        end
+
+        context 'when there is no template in category folder' do
+          let!(:category) { 'using_components_with_known_vulnerabilities' }
+          let!(:subcategory) { '' }
+          let!(:item) { '' }
+          let!(:file_name) { 'template' }
+
+          it 'returns the nil' do
+            is_expected.to be_nil
+          end
+        end
+
+        context 'when there is no template in subcategory folder' do
+          let!(:category) { 'server_security_misconfiguration' }
+          let!(:subcategory) { 'waf_bypass' }
+          let!(:item) { '' }
+          let!(:file_name) { 'template' }
+
+          it 'returns the template defined in the category folder' do
+            is_expected.to include('# Generic server security misconfiguration')
+          end
+        end
+
+        context 'when category, subcategory, items as nil values' do
+          let!(:category) { nil }
+          let!(:subcategory) { nil }
+          let!(:item) { nil }
+          let!(:file_name) {}
+
+          it 'returns the nil' do
+            is_expected.to be_nil
+          end
+        end
+      end
+
+      context 'when a user searching template with methodologies type' do
+        let!(:type) { 'methodology' }
+        let!(:field) { 'notes' }
+        let!(:category) { 'website_testing' }
+        let!(:subcategory) { 'information' }
+        let!(:item) { '' }
+        let!(:file_name) { 'template' }
+
+        it 'returns the methodology template value as string' do
+          is_expected.to include('# Information gathering')
         end
       end
     end


### PR DESCRIPTION
As BugcrowdTemplate gem
When I search for a template and the template is not there
I should climb to the parent folder until I find a template

[BC-18469](https://bugcrowd.atlassian.net/browse/BC-18469)

### Before
Earlier if there is no template for the item, it will return nil 
```
BugcrowdTemplates.get(
 type: 'submissions', field: 'description',
 category: 'server_security_misconfiguration',
 subcategory: 'clickjacking',
 item: 'form_input',
 file_name: 'template')
```


### After
If there is no template for the item, it will check the subcategory folder to fetch the template
```
BugcrowdTemplates.get(
 type: 'submissions', field: 'description',
 category: 'server_security_misconfiguration',
 subcategory: 'clickjacking',
 item: 'form_input',
 file_name: 'template')
```

### Screen
if there is no template for the item,
<img width="1304" alt="Screenshot 2022-03-22 at 2 18 04 AM" src="https://user-images.githubusercontent.com/57894121/159361630-07d53c79-2d10-40fc-abe8-8785fb801d94.png">

You can see the template for the subcategory item,
<img width="1680" alt="Screenshot 2022-03-22 at 2 20 08 AM" src="https://user-images.githubusercontent.com/57894121/159361654-6697a0df-505e-4f97-bbca-05c9c6fa8a81.png">

### Technical explanations
- Added the default behaviour for the `BugcrowdTemplate` gem for the `template.md` and `guidance.md`
- It will work for submissions's `description` & methodologies's `notes`
- if there is no templates in subcategory or item folder, it will climb up to category level to display the `template` or `guidance`

### Testing
1. Run the `bin/console` to open the console
2. Run the below commands in your console, to check the templates

```
BugcrowdTemplates.get(
 type: 'submissions',
 field: 'description',
 category: 'server_security_misconfiguration',
 subcategory: 'clickjacking',
 item: 'form_input',
 file_name: 'template')
```

```
BugcrowdTemplates.get(
 type: 'submissions', field: 'description',
 category: 'server_security_misconfiguration',
 subcategory: 'clickjacking',
 file_name: 'template')
```

```
BugcrowdTemplates.get(
type: 'submissions',
 field: 'description',
 category: 'server_security_misconfiguration',
 file_name: 'template')
```

```
You can check the multiple scenarios while running the below commands in your `bin/console`
1. Category, subcategory, item
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'server_security_misconfiguration', subcategory: 'clickjacking', item: 'form_input', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'server_security_misconfiguration', subcategory: 'clickjacking', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'server_security_misconfiguration', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'cross_site_scripting_xss', subcategory: 'reflected', item: 'non_self', file_name: 'template')


2. Category, subcategory
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', subcategory: 'outdated_software_version', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', file_name: 'template')

3. Without template 
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', file_name: 'template')


4. Without any values
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: '', subcategory: '', item: '', file_name: '')

5. With methodology
BugcrowdTemplates.get(type: 'methodology', field: 'notes', category: 'website_testing', subcategory: '', file_name: 'information')


BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', subcategory: 'outdated_software_version', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', subcategory: 'captcha_bypass', file_name: 'template')
BugcrowdTemplates.get(type: 'submissions', field: 'description', category: 'using_components_with_known_vulnerabilities', file_name: 'template')
```

<img width="1680" alt="Screenshot 2022-03-22 at 2 20 08 AM" src="https://user-images.githubusercontent.com/57894121/159362417-7cb3aedc-a87d-471e-b628-4aad9fec0a0c.png">


