### PR TITLE
Update template.md: L5 Removed Duplicate Space L8-13 List in BlockQuote…

### DIFF
--- a/submissions/description/broken_access_control/idor/template.md
+++ b/submissions/description/broken_access_control/idor/template.md
@@ -2,36 +2,37 @@
 
 ## Overview of the Vulnerability
 
-Insecure Direct Object Reference (IDOR) occurs when there are no access control checks to verify if a request to interact with a resource is valid. An IDOR vulnerability within this application can be leveraged by an attacker to manipulate, destroy, or disclose data through their ability to bypass access controls and  horizontally or vertically escalate their privileges. 
+Insecure Direct Object Reference (IDOR) occurs when there are no access control checks to verify if a request to interact with a resource is valid. An IDOR vulnerability within this application can be leveraged by an attacker to manipulate, destroy, or disclose data through their ability to bypass access controls and horizontally or vertically escalate their privileges. 
 
 Given the type of IDOR within an application, an attacker could perform the following actions:
+>
+> - Gain unauthorized access to data from the application and retrieve privileged information
+> - Perform unauthorized operations, such as escalating their privileges within the application, or forcing a password change on a user’s account in order to takeover that account
+> - Manipulate internal application objects and elevate their privileges, alter data, or gain access to and manipulate the application’s APIs
+> - Gain direct access to files and manipulate the file system, such as uploading, downloading, adding, or deleting data, including other user’s data.
+>
 
-- Gain unauthorized access to data from the application and retrieve privileged information
-- Perform unauthorized operations, such as escalating their privileges within the application, or forcing a password change on a user’s account in order to takeover that account
-- Manipulate internal application objects and elevate their privileges, alter data, or gain access to and manipulate the application’s APIs
-- Gain direct access to files and manipulate the file system, such as uploading, downloading, adding, or deleting data, including other user’s data.
+## Business Impact:
 
-## Business Impact
+IDOR can lead to indirect financial loss through an attacker accessing, deleting, or modifying data from within the application. This could also result in reputational damage for the business through the impact to customers’ trust. The severity of the impact to the business is dependent on the sensitivity of the data being stored in, and transmitted by, the application.
 
-IDOR can lead to indirect financial loss through an attacker accessing, deleting, or modifying data from within the application. This could also result in reputational damage for the business through the impact to customers’ trust. The severity of the impact to the business is dependent on the sensitivity of the data being stored in, and transmitted by the application.
+## Steps to Reproduce:
 
-## Steps to Reproduce
-
-1. Use a browser to navigate to: {{URL}}
+1. Use a browser to navigate to the URL: {{URL}}
 1. Login to User Account A
 1. In the URL bar, modify the parameter to a different value:
 
 {{eg.<https://example.com/parameter(UserAccountB)>}}
 
-1. Observe that the application displays information of User Account B, as seen in the screenshot below:  
+1. Observe that the application displays information of User Account B, as seen in the screenshot(s) below:  
+>
+> {{screenshot}}
 
-{{screenshot}}
-
-## Proof of Concept (PoC)
+## Proof of Concept (PoC):
 
 Below is a screenshot demonstrating the exposed object executing:
-
-{{screenshot}}
+>
+> {{screenshot}}
 
 A malicious attacker could leverage this IDOR vulnerability to extract data by using the following payload:  
   
@@ -39,7 +40,7 @@ A malicious attacker could leverage this IDOR vulnerability to extract data by u
 {{payload}}
 ```
 
-The following screenshot demonstrates this additional impact:
-
-{{screenshot}}
+The following screenshot(s) demonstrate(s) this additional impact:
+>
+> {{screenshot}}
 


### PR DESCRIPTION
… L15 19 31 Colon Added - clarity L17 Corrected incorrect use of conjunctive clauses L21 Added to the URL - clarity L27 L43 - Mistake proofing language around screenshots L28-29 34-35 44-45 Placed Screenshots in Blockquote

L5 - Line contained addition spacing in paragraph between "And" and "Horizontally.  

L8-13 - List items in blockquotes adds visual clarity to the presentation of items and reduces information signal confusion, in both Tracker and Report. This item must be fixed on every instance of this item that I find, having this change in Markdown template will reduce the # of cycles spent editing findings in tracker. 

L15 19 31 - Bolded subsection headings with a comma reduce the time taken to convert to report format.

L17 - Paragraph incorrectly joins two clauses. One solution is to add the specified comma. 

L21 - adding "to the URL" to this line aids readability for the non-technical audience, which is a concern for reporting since our items will be accessible by non-technical administrative staff at any client's office/workspace. 

L27 43 Screenshot(s) et al - adding this language reduces the time required to ensure that language surrounding screenshot usage is in a correct subject verb agreement.  some researchers, especially non-native english speaking global researchers, do not excel intuitively at the english language like most native english speakers.  Rather than provide additional training to every researcher, or pay for additional editing hours, fix the problem at an administrative level with a language that is error-proof in all usages and in line with professional writing standards worldwide.  

L 28-29 34-35 44-45 - Screenshots in blockqoute adds clarity to the communication of information in tracker.  Screenshots in blockqoute also enable easier editing in Report.  In tracker, blockqoute clearly delineates that a screenshot is attached to, or a sub item, of the step it is listed under.  in report, the blockqoute separates the items from the 0 indent and enables programmatic adjustment to photo items in editor without compromising the integrity of the document's formatting.