### PR TITLE
Update .markdownlint.json to ignore first line as heading

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,6 +6,6 @@
   "line_length": false,
   "fenced-code-language": false,
   "no-emphasis-as-heading": false,
-  "first-line-heading": false,
+  "MD041": false,
   "blanks-around-headings": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,5 +6,6 @@
   "line_length": false,
   "fenced-code-language": false,
   "no-emphasis-as-heading": false,
+  "first-line-heading": false,
   "blanks-around-headings": false
 }


### PR DESCRIPTION
Ignoring first line as heading allows a template to begin with the description contents for each submission type.