### PR TITLE
Sensitive Data Exposure categories - update business impact, steps

### DIFF
--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
@@ -4,12 +4,13 @@ The descriptive stack trace leaked by this application shows versions of softwar
 
 **Business Impact**
 
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
 This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 
 1. Use a browser to navigate to: {{URL}}
-1. Observe detailed error message showing a descriptive stack trace
+2. Observe detailed error message showing a descriptive stack trace
 
 **Proof of Concept (PoC)**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
@@ -5,7 +5,7 @@ The descriptive stack trace leaked by this application shows versions of softwar
 **Business Impact**
 
 This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/descriptive_stack_trace/template.md
@@ -4,8 +4,8 @@ The descriptive stack trace leaked by this application shows versions of softwar
 
 **Business Impact**
 
-This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, 
+leading to financial loss and impact customers’ trust in the application.
 
 **Steps to Reproduce**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/detailed_server_configuration/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/detailed_server_configuration/template.md
@@ -4,12 +4,13 @@ The detailed server configuration leaked by this application shows which version
 
 **Business Impact**
 
-This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
+It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 
 1. Use a browser to navigate to: {{URL}}
-1. Observe detailed error message showing detailed server configuration
+2. Observe detailed error message showing detailed server configuration
 
 **Proof of Concept (PoC)**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/detailed_server_configuration/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/detailed_server_configuration/template.md
@@ -4,8 +4,8 @@ The detailed server configuration leaked by this application shows which version
 
 **Business Impact**
 
-This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, 
+leading to financial loss and impact customers’ trust in the application.
 
 **Steps to Reproduce**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/full_path_disclosure/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/full_path_disclosure/template.md
@@ -4,12 +4,13 @@ The full path disclosure leaked by this application displays implementation info
 
 **Business Impact**
 
-This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
+It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 
 1. Use a browser to navigate to: {{URL}}
-1. Observe detailed error message showing the full path disclosure
+2. Observe detailed error message showing the full path disclosure
 
 **Proof of Concept (PoC)**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/full_path_disclosure/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/full_path_disclosure/template.md
@@ -4,8 +4,8 @@ The full path disclosure leaked by this application displays implementation info
 
 **Business Impact**
 
-This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, 
+leading to financial loss and impact customers’ trust in the application.
 
 **Steps to Reproduce**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
@@ -3,7 +3,7 @@ Visible detailed error pages are a result of improper error handling which intro
 **Business Impact**
 
 This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
@@ -2,12 +2,13 @@ Visible detailed error pages are a result of improper error handling which intro
 
 **Business Impact**
 
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
 This vulnerability can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
 
 **Steps to Reproduce**
 
 1. Use a browser to navigate to: {{URL}}
-1. Observe detailed error message
+2. Observe detailed error message
 
 **Proof of Concept (PoC)**
 

--- a/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
+++ b/submissions/description/sensitive_data_exposure/visible_detailed_error_page/template.md
@@ -2,8 +2,8 @@ Visible detailed error pages are a result of improper error handling which intro
 
 **Business Impact**
 
-This vulnerability could enable attacker exploitation that will disrupt product or service availability, leading to direct financial loss.
-It can impact customers’ trust in the application which can result in reputational damage for the business and indirect financial losses.
+This vulnerability could enable attacker exploitation that will disrupt product or service availability, 
+leading to financial loss and impact customers’ trust in the application.
 
 **Steps to Reproduce**
 


### PR DESCRIPTION
This PR updates the Sensitive Data Exposure Categories templates:
 - I wanted to update the Business Impact section to highlight these vulnerabilities could enable exploitation leading to loss of product or service availability, which would lead to direct financial loss impact.
Reputational risk, which is the curent focus of these business impact descriptions, is secondary and less important to potential impacts to service availability.
 - Updated the steps list so it doesn't show two step 1's next to each other. I see these templates typically list the observed/actual in its own step one, this makes less sense if there is only one StR step.

[NO_TRAIN]::